### PR TITLE
disable tls check for local traffic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # CMake build
 build/
+built/
 
 # Scripts bundle
 dist/

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -2,6 +2,7 @@
 
 #include <cpr/cpr.h>
 #include <string>
+#include <regex>
 
 #include "HttpHeader.h"
 #include "HttpMethod.h"
@@ -13,7 +14,9 @@ HttpPlugin* HttpClient::plugin = HttpPlugin::get();
 
 bool HttpClient::is_secure(const Red::CString& p_url) {
   std::string url(p_url.c_str());
-  std::regex local_regex("^(https?:\/\/)?(localhost|127\.0\.0\.1|192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1]))");
+//  std::regex local_regex("^(https?:\/\/)?(localhost|127\.0\.0\.1|192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1]))");
+  std::regex local_regex("^(https?:\\/\\/)?(localhost|127\\.0\\.0\\.1|192\\.168\\.|10\\.|172\\.(1[6-9]|2[0-9]|3[0-1]))");
+
   if (std::regex_search(url, local_regex)) {
       return true;
   }

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -13,9 +13,11 @@ HttpPlugin* HttpClient::plugin = HttpPlugin::get();
 
 bool HttpClient::is_secure(const Red::CString& p_url) {
   std::string url(p_url.c_str());
-
-//  return url.starts_with("https://");
-  return true;
+  std::regex local_regex("^(https?:\/\/)?(localhost|127\.0\.0\.1|192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1]))");
+  if (std::regex_search(url, local_regex)) {
+      return true;
+  }
+  return url.starts_with("https://");
 }
 
 cpr::Header HttpClient::build_headers(

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -14,7 +14,6 @@ HttpPlugin* HttpClient::plugin = HttpPlugin::get();
 
 bool HttpClient::is_secure(const Red::CString& p_url) {
   std::string url(p_url.c_str());
-//  std::regex local_regex("^(https?:\/\/)?(localhost|127\.0\.0\.1|192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1]))");
   std::regex local_regex("^(https?:\\/\\/)?(localhost|127\\.0\\.0\\.1|192\\.168\\.|10\\.|172\\.(1[6-9]|2[0-9]|3[0-1]))");
 
   if (std::regex_search(url, local_regex)) {

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -14,7 +14,8 @@ HttpPlugin* HttpClient::plugin = HttpPlugin::get();
 bool HttpClient::is_secure(const Red::CString& p_url) {
   std::string url(p_url.c_str());
 
-  return url.starts_with("https://");
+//  return url.starts_with("https://");
+  return true;
 }
 
 cpr::Header HttpClient::build_headers(


### PR DESCRIPTION
i want to use RedHttp with local llm, but it doesnt have tls, so i disabled using a regex to check for local ip.

fyi i used an llm to make the regex, and did some cursory testing in a regex tester, so you may want to check it's legit.